### PR TITLE
Cleaned up pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -20,6 +20,7 @@ jobs:
       group: pkgdown-${{ github.event_name != 'pull_request' || github.run_id }}
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      RENV_CONFIG_AUTOLOADER_ENABLED: FALSE
     permissions:
       contents: write
     steps:
@@ -29,6 +30,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
         with:
+          r-version: latest
           use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2


### PR DESCRIPTION
`renv` was being auto-activated in the pkgdown workflow via `.Rprofile`, causing the job to run inside an `renv` environment despite using setup-r-dependencies.

This created a mixed setup (DESCRIPTION-based install with `renv` active), which is a brittle workflow.

This PR disables `renv` autoloading for the pkgdown job so it runs in a clean, DESCRIPTION-based environment. This ensures pkgdown builds against the package’s declared dependencies rather than a project-specific `renv` state.